### PR TITLE
fix(auth): Use a registry default if one is not specified

### DIFF
--- a/utils/create_regclient_client.go
+++ b/utils/create_regclient_client.go
@@ -23,6 +23,10 @@ func CreateRegclientClient(registry string, username string, password string) *r
 		host.RepoAuth = true
 		customHost = true
 	}
+	if customHost && registry == "" {
+		host.Name = config.DockerRegistry
+		host.Hostname = config.DockerRegistryDNS
+	}
 
 	var regclientOpts []regclient.Opt
 


### PR DESCRIPTION
# Completed
- Used a similar technique to `regclient` in setting the default registry if one is not specified

This is the code they have:
![image](https://github.com/kerren/dockem/assets/24960997/1f0bc363-03bd-4d61-bd99-536cd89ce409)
