### PR TITLE
fix(build)!: Remove the docker build flags as an option because we don't currently do anything with them

### DIFF
--- a/cli/cmd/build.go
+++ b/cli/cmd/build.go
@@ -27,7 +27,6 @@ otherwise, build the new image and push it to the specified tag(s).`,
 		versionFile, _ := cmd.Flags().GetString("version-file")
 		utils.AssertFileExists(versionFile, "ERROR: The file '%s' does not exist. Please specify the path to the file that holds the version you would like to use in the build. This is a JSON file that must have the 'version' key.")
 
-		dockerBuildFlags, _ := cmd.Flags().GetStringArray("docker-build-flags")
 		dockerPassword, _ := cmd.Flags().GetString("docker-password")
 		dockerUsername, _ := cmd.Flags().GetString("docker-username")
 		ignoreBuildDirectory, _ := cmd.Flags().GetBool("ignore-build-directory")
@@ -41,7 +40,6 @@ otherwise, build the new image and push it to the specified tag(s).`,
 		// Now we can create the build docker image params struct
 		buildDockerImageParams := utils.BuildDockerImageParams{
 			Directory:            directory,
-			DockerBuildFlags:     dockerBuildFlags,
 			DockerPassword:       dockerPassword,
 			DockerUsername:       dockerUsername,
 			DockerfilePath:       dockerfilePath,

--- a/cli/cmd/build.go
+++ b/cli/cmd/build.go
@@ -69,7 +69,6 @@ func init() {
 	buildCmd.Flags().StringArrayP("watch-file", "w", []string{}, "Watch for changes on a specific file or files")
 	buildCmd.Flags().StringArrayP("watch-directory", "W", []string{}, "Watch for changes in a directory or directories")
 	buildCmd.Flags().StringP("directory", "d", "./", "(required) The directory that should be used as the context for the Docker build")
-	buildCmd.Flags().StringArrayP("docker-build-flags", "b", []string{}, "Any additional build flags you would like to pass directly into the docker build command")
 	buildCmd.Flags().StringP("dockerfile-path", "f", "./Dockerfile", "(required) The path to the Dockerfile that should be used to build the image")
 	buildCmd.Flags().StringP("image-name", "i", "", "(required) The name of the image you are building")
 	buildCmd.Flags().BoolP("latest", "l", false, "Whether to push the latest tag with this image")

--- a/cli/utils/build_docker_image_params.go
+++ b/cli/utils/build_docker_image_params.go
@@ -2,7 +2,6 @@ package utils
 
 type BuildDockerImageParams struct {
 	Directory            string
-	DockerBuildFlags     []string
 	DockerPassword       string
 	DockerUsername       string
 	DockerfilePath       string

--- a/cli/utils/build_docker_image_test.go
+++ b/cli/utils/build_docker_image_test.go
@@ -35,7 +35,6 @@ func TestStandardBuildWhereHashExists(t *testing.T) {
 
 	params := BuildDockerImageParams{
 		Directory:            directory,
-		DockerBuildFlags:     []string{},
 		DockerPassword:       password,
 		DockerUsername:       username,
 		DockerfilePath:       directory + "/Dockerfile",
@@ -80,7 +79,6 @@ func TestStandardBuildWhereHashDoesNotExist(t *testing.T) {
 
 	params := BuildDockerImageParams{
 		Directory:            directory,
-		DockerBuildFlags:     []string{},
 		DockerPassword:       password,
 		DockerUsername:       username,
 		DockerfilePath:       directory + "/Dockerfile",
@@ -126,7 +124,6 @@ func TestDockerfileOutsideOfBuildContext(t *testing.T) {
 
 	params := BuildDockerImageParams{
 		Directory:            directory,
-		DockerBuildFlags:     []string{},
 		DockerPassword:       password,
 		DockerUsername:       username,
 		DockerfilePath:       dockerfilePath,


### PR DESCRIPTION
# Completed
- Remove the docker build flags from the options

Why? We currently don't do anything with them. Perhaps, in the future, I would add more flags to the build command, but this is not something I'd like to do currently.