### PR TITLE
feat(version): Add the version to the CLI and build it in using ldflags

### DIFF
--- a/cli/cmd/build.go
+++ b/cli/cmd/build.go
@@ -7,8 +7,9 @@ import (
 )
 
 var buildCmd = &cobra.Command{
-	Use:   "build",
-	Short: "Build the new Docker image",
+	Use:     "build",
+	Short:   "Build the new Docker image",
+	Version: Version,
 	Long: `Check the files or folders specified and compare the hash to what has already
 been built. If it has been built, then skip the build and copy the tag,
 otherwise, build the new image and push it to the specified tag(s).`,

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -6,6 +6,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Check https://akrabat.com/setting-the-version-of-a-go-application-when-building/ for details
+// on the versioning of the application
+var Version = "dev-build"
+
 var rootCmd = &cobra.Command{
 	Use:   "dockem",
 	Short: "Use this application to build docker images only when a change has taken place",
@@ -13,6 +17,7 @@ var rootCmd = &cobra.Command{
 if anything has changed since the last build. If nothing has changed, it will 
 copy the tag across to the new repository without having to push. Otherwise, 
 it'll trigger a rebuild.`,
+	Version: Version,
 }
 
 func Execute() {

--- a/taskfile.yml
+++ b/taskfile.yml
@@ -45,6 +45,8 @@ tasks:
       - |
         # Shoutout to Rob Allen for this amazing article
         # https://akrabat.com/building-go-binaries-for-different-platforms
+        # https://akrabat.com/setting-the-version-of-a-go-application-when-building/
+
         rm -rf ./release
         cd cli
         version=`git describe --tags HEAD`
@@ -74,6 +76,7 @@ tasks:
 
           echo "Building release/$output_name..."
           env GOOS=$GOOS GOARCH=$GOARCH go build \
+            -ldflags "-X dockem/cmd.Version=$version" \
             -o ../release/$output_name
           if [ $? -ne 0 ]; then
               echo 'An error has occurred! Aborting.'


### PR DESCRIPTION
# Completed
- Followed the instructions presented by [Rob Allen](https://akrabat.com/setting-the-version-of-a-go-application-when-building/) to set the version of the CLI during the build process