### PR TITLE
feat(refactor): Use a consistent print function across the code

### DIFF
--- a/cli/cmd/build.go
+++ b/cli/cmd/build.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"dockem/utils"
+	"fmt"
 
 	"github.com/spf13/cobra"
 )
@@ -58,7 +59,7 @@ otherwise, build the new image and push it to the specified tag(s).`,
 		// Finally, we push this off to the build docker image function
 		_, err := utils.BuildDockerImage(buildDockerImageParams)
 		if err != nil {
-			print("\n\n")
+			fmt.Print("\n\n")
 			panic(err)
 		}
 	},

--- a/cli/utils/build_docker_image.go
+++ b/cli/utils/build_docker_image.go
@@ -30,7 +30,7 @@ func BuildDockerImage(params BuildDockerImageParams) (BuildLog, error) {
 	if !params.IgnoreBuildDirectory {
 		directoryHash, err := dirhash.HashDir(params.Directory, "", dirhash.Hash1)
 		if err != nil {
-			print(fmt.Sprintf("ERROR: An error ocurred when hashing the build directory, please ensure it exists and is not empty. You specified %s as the directory\n", params.Directory))
+			fmt.Printf("ERROR: An error ocurred when hashing the build directory, please ensure it exists and is not empty. You specified %s as the directory\n", params.Directory)
 			return buildLog, err
 		}
 		overallHash += directoryHash
@@ -39,7 +39,7 @@ func BuildDockerImage(params BuildDockerImageParams) (BuildLog, error) {
 	// Hash the Dockerfile
 	dockerfileHash, err := dirhash.Hash1([]string{params.DockerfilePath}, osOpen)
 	if err != nil {
-		print(fmt.Sprintf("ERROR: An error ocurred when hashing the Dockerfile, please ensure it exists. You specified %s as the Dockerfile\n", params.DockerfilePath))
+		fmt.Printf("ERROR: An error ocurred when hashing the Dockerfile, please ensure it exists. You specified %s as the Dockerfile\n", params.DockerfilePath)
 		return buildLog, err
 	}
 	overallHash += dockerfileHash
@@ -69,7 +69,7 @@ func BuildDockerImage(params BuildDockerImageParams) (BuildLog, error) {
 	imageName := GenerateDockerImageName(params.Registry, params.ImageName, imageHash)
 	r, err := ref.New(imageName)
 	if err != nil {
-		print(fmt.Sprintf("ERROR: An error ocurred when trying to parse the image: %s\n", imageName))
+		fmt.Printf("ERROR: An error ocurred when trying to parse the image: %s\n", imageName)
 		return buildLog, err
 	}
 	buildLog.hashedImageName = imageName
@@ -80,7 +80,7 @@ func BuildDockerImage(params BuildDockerImageParams) (BuildLog, error) {
 	buildLog.hashExists = exists
 
 	if exists {
-		print(fmt.Sprintf("The image hash %s already exists on the registry, we can now copy this to the other tags!\n", imageHash))
+		fmt.Printf("The image hash %s already exists on the registry, we can now copy this to the other tags!\n", imageHash)
 		// If the image already exists, we just need to copy the tags across
 		copyError := CopyExistingImageTag(params, version, imageName, &client, &buildLog)
 		if copyError != nil {
@@ -88,7 +88,7 @@ func BuildDockerImage(params BuildDockerImageParams) (BuildLog, error) {
 		}
 	} else {
 		// We need to build the image and then we push it to the registry
-		print(fmt.Sprintf("The image hash %s does not exist on the registry, we will now build the image and push it to the registry\n", imageHash))
+		fmt.Printf("The image hash %s does not exist on the registry, we will now build the image and push it to the registry\n", imageHash)
 
 		dockerClient, pushOptions, err := CreateDockerClient(params.DockerUsername, params.DockerPassword, params.Registry)
 		if err != nil {
@@ -104,7 +104,7 @@ func BuildDockerImage(params BuildDockerImageParams) (BuildLog, error) {
 		}
 		buildLog.localTag = localTag
 
-		print("Docker build complete, pushing the image to the registry\n")
+		fmt.Print("Docker build complete, pushing the image to the registry\n")
 
 		// Now we push the hashed image and then all of the other tags that the
 		// user has specified
@@ -113,7 +113,7 @@ func BuildDockerImage(params BuildDockerImageParams) (BuildLog, error) {
 			return buildLog, hashedImageNameError
 		}
 
-		print(fmt.Sprintf("The image has been pushed to the registry with the hash %s\n", imageName))
+		fmt.Printf("The image has been pushed to the registry with the hash %s\n", imageName)
 
 		// Now that the hashed image has been pushed, we can push all of the other tags
 		tagAndPushImagesError := TagAndPushNewImages(params, version, localTag, dockerClient, pushOptions, &buildLog)

--- a/cli/utils/build_image.go
+++ b/cli/utils/build_image.go
@@ -26,7 +26,7 @@ func BuildImage(params BuildDockerImageParams, imageHash string, dockerClient *c
 	})
 
 	if imageBuildError != nil {
-		print(fmt.Sprintf("ERROR: An error ocurred when trying to build the image: %s\n", imageBuildError))
+		fmt.Printf("ERROR: An error ocurred when trying to build the image: %s\n", imageBuildError)
 		return "", imageBuildError
 	}
 	termFd, isTerm := term.GetFdInfo(os.Stderr)

--- a/cli/utils/check_manifest_head.go
+++ b/cli/utils/check_manifest_head.go
@@ -11,15 +11,15 @@ import (
 
 func CheckManifestHead(tag string, ref ref.Ref, client *regclient.RegClient) bool {
 	mOpts := []regclient.ManifestOpts{}
-	print(fmt.Sprintf("Checking for the image hash %s on the registry\n", tag))
+	fmt.Printf("Checking for the image hash %s on the registry\n", tag)
 	_, manifestError := client.ManifestHead(context.Background(), ref, mOpts...)
 	if manifestError != nil {
-		print(fmt.Sprintf("The image hash %s does not exist on the registry or we were unable to pull it\n", tag))
+		fmt.Printf("The image hash %s does not exist on the registry or we were unable to pull it\n", tag)
 		if strings.Contains(manifestError.Error(), "failed to request manifest head") {
-			print("WARN: Unable to pull the details from the registry, please ensure you have the correct credentials.\n")
-			print("WARN: The build will continue, but this should be investigated\n")
+			fmt.Print("WARN: Unable to pull the details from the registry, please ensure you have the correct credentials.\n")
+			fmt.Print("WARN: The build will continue, but this should be investigated\n")
 		}
-		print(manifestError.Error())
+		fmt.Print(manifestError.Error())
 		return false
 	}
 	return true

--- a/cli/utils/copy_docker_image.go
+++ b/cli/utils/copy_docker_image.go
@@ -11,13 +11,13 @@ import (
 func CopyDockerImage(client *regclient.RegClient, fromImageName string, toImageName string) error {
 	rFrom, errFrom := ref.New(fromImageName)
 	if errFrom != nil {
-		print(fmt.Sprintf("ERROR: Could not parse the from image name '%s'. Please ensure that the image name is correct.\n", fromImageName))
+		fmt.Printf("ERROR: Could not parse the from image name '%s'. Please ensure that the image name is correct.\n", fromImageName)
 		return errFrom
 	}
 
 	rTo, errTo := ref.New(toImageName)
 	if errTo != nil {
-		print(fmt.Sprintf("ERROR: Could not parse the to image name '%s'. Please ensure that the image name is correct.\n", toImageName))
+		fmt.Printf("ERROR: Could not parse the to image name '%s'. Please ensure that the image name is correct.\n", toImageName)
 		return errTo
 	}
 
@@ -26,7 +26,7 @@ func CopyDockerImage(client *regclient.RegClient, fromImageName string, toImageN
 	err := client.ImageCopy(context.Background(), rFrom, rTo, opts...)
 
 	if err != nil {
-		print(fmt.Sprintf("ERROR: An error occurred when copying the image from '%s' to '%s'\n", fromImageName, toImageName))
+		fmt.Printf("ERROR: An error occurred when copying the image from '%s' to '%s'\n", fromImageName, toImageName)
 		return err
 	}
 	return nil

--- a/cli/utils/copy_existing_image_tag.go
+++ b/cli/utils/copy_existing_image_tag.go
@@ -10,7 +10,7 @@ func CopyExistingImageTag(params BuildDockerImageParams, version string, imageNa
 	for _, tag := range params.Tag {
 		tagVersion := fmt.Sprintf("%s-%s", tag, version)
 		targetImageName := GenerateDockerImageName(params.Registry, params.ImageName, tagVersion)
-		print(fmt.Sprintf("Copying the image to the new tag: %s\n", targetImageName))
+		fmt.Printf("Copying the image to the new tag: %s\n", targetImageName)
 		copyError := CopyDockerImage(*client, imageNameWithHash, targetImageName)
 		if copyError != nil {
 			return copyError
@@ -20,7 +20,7 @@ func CopyExistingImageTag(params BuildDockerImageParams, version string, imageNa
 	if len(params.Tag) == 0 && !params.Latest && !params.MainVersion {
 		// At this point, we just deploy it straight to the main version
 		mainVersionImageName := GenerateDockerImageName(params.Registry, params.ImageName, version)
-		print(fmt.Sprintf("WARN: No tags were specified and you have not selected the --latest flag, so the image will be copied to the main version: %s\n", mainVersionImageName))
+		fmt.Printf("WARN: No tags were specified and you have not selected the --latest flag, so the image will be copied to the main version: %s\n", mainVersionImageName)
 		copyError := CopyDockerImage(*client, imageNameWithHash, mainVersionImageName)
 		if copyError != nil {
 			return copyError
@@ -29,7 +29,7 @@ func CopyExistingImageTag(params BuildDockerImageParams, version string, imageNa
 	}
 	if params.Latest {
 		latestImageName := GenerateDockerImageName(params.Registry, params.ImageName, "latest")
-		print(fmt.Sprintf("You have selected the --latest flag, so the image will be copied to the latest tag: %s\n", latestImageName))
+		fmt.Printf("You have selected the --latest flag, so the image will be copied to the latest tag: %s\n", latestImageName)
 		copyError := CopyDockerImage(*client, imageNameWithHash, latestImageName)
 		if copyError != nil {
 			return copyError
@@ -38,7 +38,7 @@ func CopyExistingImageTag(params BuildDockerImageParams, version string, imageNa
 	}
 	if params.MainVersion {
 		mainVersionImageName := GenerateDockerImageName(params.Registry, params.ImageName, version)
-		print(fmt.Sprintf("You have selected the --main-version flag, so the image will be copied to the main version: %s\n", mainVersionImageName))
+		fmt.Printf("You have selected the --main-version flag, so the image will be copied to the main version: %s\n", mainVersionImageName)
 		copyError := CopyDockerImage(*client, imageNameWithHash, mainVersionImageName)
 		if copyError != nil {
 			return copyError

--- a/cli/utils/create_docker_client.go
+++ b/cli/utils/create_docker_client.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/registry"
@@ -14,7 +15,7 @@ func CreateDockerClient(username string, password string, registryName string) (
 	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 
 	if err != nil {
-		print("ERROR: An error occurred when creating the docker client. Please ensure that the docker daemon is running and that you have the correct permissions to access it.\n")
+		fmt.Print("ERROR: An error occurred when creating the docker client. Please ensure that the docker daemon is running and that you have the correct permissions to access it.\n")
 		return nil, image.PushOptions{}, err
 	}
 

--- a/cli/utils/extract_version.go
+++ b/cli/utils/extract_version.go
@@ -10,17 +10,17 @@ func ExtractVersion(versionFilePath string) (string, error) {
 
 	versionFile, versionFileError := os.Open(versionFilePath)
 	if versionFileError != nil {
-		print(fmt.Sprintf("ERROR: An error ocurred when trying to open the version file: %s\n", versionFilePath))
+		fmt.Printf("ERROR: An error ocurred when trying to open the version file: %s\n", versionFilePath)
 		return "", versionFileError
 	}
 	defer versionFile.Close()
 	bytes, _ := io.ReadAll(versionFile)
 	parsedVersionFile, parsedVersionFileError := ParseVersionFileJson(bytes)
 	if parsedVersionFileError != nil {
-		print(fmt.Sprintf("ERROR: An error ocurred when trying to parse the version file: %s\n", versionFilePath))
+		fmt.Printf("ERROR: An error ocurred when trying to parse the version file: %s\n", versionFilePath)
 		return "", parsedVersionFileError
 	}
 	version := "v" + parsedVersionFile.Version
-	print(fmt.Sprintf("The version of the image being built is: %s\n", version))
+	fmt.Printf("The version of the image being built is: %s\n", version)
 	return version, nil
 }

--- a/cli/utils/hash_watch_directories.go
+++ b/cli/utils/hash_watch_directories.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"fmt"
 	"sort"
 
 	"golang.org/x/mod/sumdb/dirhash"
@@ -14,9 +15,9 @@ func HashWatchDirectories(watchDirectories []string) (string, error) {
 		for _, directory := range watchDirectories {
 			directoryHash, err := dirhash.HashDir(directory, "", dirhash.Hash1)
 			if err != nil {
-				print("ERROR: An error ocurred when hashing the watch directories, please ensure they all exist, they are listed as follows:\n")
+				fmt.Print("ERROR: An error ocurred when hashing the watch directories, please ensure they all exist, they are listed as follows:\n")
 				for _, dir := range watchDirectories {
-					print(dir + "\n")
+					fmt.Print(dir + "\n")
 				}
 				return "", err
 			}

--- a/cli/utils/hash_watch_files.go
+++ b/cli/utils/hash_watch_files.go
@@ -1,6 +1,10 @@
 package utils
 
-import "golang.org/x/mod/sumdb/dirhash"
+import (
+	"fmt"
+
+	"golang.org/x/mod/sumdb/dirhash"
+)
 
 func HashWatchFiles(watchFiles []string) (string, error) {
 
@@ -10,7 +14,7 @@ func HashWatchFiles(watchFiles []string) (string, error) {
 		if err != nil {
 			print("ERROR: An error ocurred when hashing the watch files, please ensure they all exist, they are listed as follows:\n")
 			for _, file := range watchFiles {
-				print(file + "\n")
+				fmt.Print(file + "\n")
 			}
 			return "", err
 		}

--- a/cli/utils/tag_and_push_image.go
+++ b/cli/utils/tag_and_push_image.go
@@ -15,13 +15,13 @@ func TagAndPushImage(fromImage string, toImage string, dockerClient *client.Clie
 
 	tagErr := dockerClient.ImageTag(context.Background(), fromImage, toImage)
 	if tagErr != nil {
-		print(fmt.Sprintf("ERROR: An error ocurred when trying to tag the image from %s to %s\n", fromImage, toImage))
+		fmt.Printf("ERROR: An error ocurred when trying to tag the image from %s to %s\n", fromImage, toImage)
 		return tagErr
 	}
 
 	reader, pushError := dockerClient.ImagePush(context.Background(), toImage, pushOptions)
 	if pushError != nil {
-		print(fmt.Sprintf("ERROR: An error ocurred when trying to push the image: %s\n", toImage))
+		fmt.Printf("ERROR: An error ocurred when trying to push the image: %s\n", toImage)
 		return pushError
 	}
 	termFd, isTerm := term.GetFdInfo(os.Stderr)

--- a/cli/utils/tag_and_push_new_images.go
+++ b/cli/utils/tag_and_push_new_images.go
@@ -11,7 +11,7 @@ func TagAndPushNewImages(params BuildDockerImageParams, version string, localTag
 	for _, tag := range params.Tag {
 		versionTag := fmt.Sprintf("%s-%s", tag, version)
 		targetImageName := GenerateDockerImageName(params.Registry, params.ImageName, versionTag)
-		print(fmt.Sprintf("Pushing the image to the new tag: %s\n", targetImageName))
+		fmt.Printf("Pushing the image to the new tag: %s\n", targetImageName)
 		err := TagAndPushImage(localTag, targetImageName, dockerClient, pushOptions)
 		if err != nil {
 			return err
@@ -21,7 +21,7 @@ func TagAndPushNewImages(params BuildDockerImageParams, version string, localTag
 	if len(params.Tag) == 0 && !params.Latest && !params.MainVersion {
 		// At this point, we just deploy it straight to the main version
 		mainVersionImageName := GenerateDockerImageName(params.Registry, params.ImageName, version)
-		print(fmt.Sprintf("WARN: No tags were specified and you have not selected the --latest flag, so the image will be deployed to the main version: %s\n", mainVersionImageName))
+		fmt.Printf("WARN: No tags were specified and you have not selected the --latest flag, so the image will be deployed to the main version: %s\n", mainVersionImageName)
 		err := TagAndPushImage(localTag, mainVersionImageName, dockerClient, pushOptions)
 		if err != nil {
 			return err
@@ -30,7 +30,7 @@ func TagAndPushNewImages(params BuildDockerImageParams, version string, localTag
 	}
 	if params.Latest {
 		latestImageName := GenerateDockerImageName(params.Registry, params.ImageName, "latest")
-		print(fmt.Sprintf("You have selected the --latest flag, so the image will be deployed to the latest tag: %s\n", latestImageName))
+		fmt.Printf("You have selected the --latest flag, so the image will be deployed to the latest tag: %s\n", latestImageName)
 		err := TagAndPushImage(localTag, latestImageName, dockerClient, pushOptions)
 		if err != nil {
 			return err
@@ -39,7 +39,7 @@ func TagAndPushNewImages(params BuildDockerImageParams, version string, localTag
 	}
 	if params.MainVersion {
 		mainVersionImageName := GenerateDockerImageName(params.Registry, params.ImageName, version)
-		print(fmt.Sprintf("You have selected the --main-version flag, so the image will be deployed to the main version: %s\n", mainVersionImageName))
+		fmt.Printf("You have selected the --main-version flag, so the image will be deployed to the main version: %s\n", mainVersionImageName)
 		err := TagAndPushImage(localTag, mainVersionImageName, dockerClient, pushOptions)
 		if err != nil {
 			return err

--- a/cli/utils/tar_build_context.go
+++ b/cli/utils/tar_build_context.go
@@ -16,17 +16,17 @@ func TarBuildContext(params BuildDockerImageParams, dockerClient *client.Client,
 
 	absDirectoryPath, absDirectoryPathError := filepath.Abs(params.Directory)
 	if absDirectoryPathError != nil {
-		print(fmt.Sprintf("ERROR: An error ocurred when trying to get the absolute path of the directory, please check your entry for %s\n", params.Directory))
+		fmt.Printf("ERROR: An error ocurred when trying to get the absolute path of the directory, please check your entry for %s\n", params.Directory)
 		return nil, "", absDirectoryPathError
 	}
 	absDockerfilePath, absDockerfilePathError := filepath.Abs(params.DockerfilePath)
 	if absDockerfilePathError != nil {
-		print(fmt.Sprintf("ERROR: An error ocurred when trying to get the absolute path of the Dockerfile, please check your entry for %s\n", params.DockerfilePath))
+		fmt.Printf("ERROR: An error ocurred when trying to get the absolute path of the Dockerfile, please check your entry for %s\n", params.DockerfilePath)
 		return nil, "", absDockerfilePathError
 	}
 	relativeDockerfilePath, relativeDockerfilePathError := filepath.Rel(absDirectoryPath, absDockerfilePath)
 	if relativeDockerfilePathError != nil {
-		print(fmt.Sprintf("ERROR: An error ocurred when trying to get the relative path of the Dockerfile from the build directory, please check your entry for:\nDirectory %s\nDockerfile %s", absDirectoryPath, absDockerfilePath))
+		fmt.Printf("ERROR: An error ocurred when trying to get the relative path of the Dockerfile from the build directory, please check your entry for:\nDirectory %s\nDockerfile %s", absDirectoryPath, absDockerfilePath)
 		return nil, "", relativeDockerfilePathError
 	}
 	var tempDockerfileRef *os.File
@@ -37,7 +37,7 @@ func TarBuildContext(params BuildDockerImageParams, dockerClient *client.Client,
 		buildLog.customDockerfile = true
 		tempDockerfile, tempDockerfileError := os.CreateTemp(absDirectoryPath, "Dockerfile.")
 		if tempDockerfileError != nil {
-			print(fmt.Sprintf("ERROR: An error ocurred when trying to create a temporary Dockerfile for the build, please check that the directory is writable %s\n", absDirectoryPath))
+			fmt.Printf("ERROR: An error ocurred when trying to create a temporary Dockerfile for the build, please check that the directory is writable %s\n", absDirectoryPath)
 			return nil, "", tempDockerfileError
 		}
 		tempDockerfileRef = tempDockerfile
@@ -45,24 +45,24 @@ func TarBuildContext(params BuildDockerImageParams, dockerClient *client.Client,
 		defer os.Remove(tempDockerfileRef.Name())
 		dockerfileContent, dockerfileContentError := os.ReadFile(absDockerfilePath)
 		if dockerfileContentError != nil {
-			print(fmt.Sprintf("ERROR: An error ocurred when trying to read the Dockerfile, please check your entry for %s\n", absDockerfilePath))
+			fmt.Printf("ERROR: An error ocurred when trying to read the Dockerfile, please check your entry for %s\n", absDockerfilePath)
 			return nil, "", dockerfileContentError
 		}
 		_, writeError := tempDockerfile.Write(dockerfileContent)
 		if writeError != nil {
-			print(fmt.Sprintf("ERROR: An error ocurred when trying to write the Dockerfile to a temporary one for the build, please check that the directory is writable %s\n", absDirectoryPath))
+			fmt.Printf("ERROR: An error ocurred when trying to write the Dockerfile to a temporary one for the build, please check that the directory is writable %s\n", absDirectoryPath)
 			return nil, "", writeError
 		}
 		relativeDockerfilePath, relativeDockerfilePathError = filepath.Rel(absDirectoryPath, tempDockerfile.Name())
 		if relativeDockerfilePathError != nil {
-			print(fmt.Sprintf("ERROR: An error ocurred when trying to get the relative path of the Dockerfile from the build directory, please check your entry for:\nDirectory %s\nDockerfile %s", absDirectoryPath, tempDockerfile.Name()))
+			fmt.Printf("ERROR: An error ocurred when trying to get the relative path of the Dockerfile from the build directory, please check your entry for:\nDirectory %s\nDockerfile %s", absDirectoryPath, tempDockerfile.Name())
 			return nil, "", relativeDockerfilePathError
 		}
 	}
 
 	reader, tarErr := archive.TarWithOptions(absDirectoryPath, &archive.TarOptions{})
 	if tarErr != nil {
-		print(fmt.Sprintf("ERROR: An error ocurred when trying to archive the directory to send to the builder: %s\n", tarErr))
+		fmt.Printf("ERROR: An error ocurred when trying to archive the directory to send to the builder: %s\n", tarErr)
 		return nil, "", tarErr
 	}
 
@@ -79,7 +79,7 @@ func TarBuildContext(params BuildDockerImageParams, dockerClient *client.Client,
 		// the temporary file before going to the build process.
 		data, readErr := io.ReadAll(reader)
 		if readErr != nil {
-			print(fmt.Sprintf("ERROR: An error ocurred when trying to read the tar stream: %s\n", readErr))
+			fmt.Printf("ERROR: An error ocurred when trying to read the tar stream: %s\n", readErr)
 			return nil, "", readErr
 		}
 		outputReader = io.NopCloser(bytes.NewReader(data))


### PR DESCRIPTION
# Completed
- Use `fmt.Print` and `fmt.Printl` instead of `print` and `print(fmt.Sprintf...`
